### PR TITLE
Opus 4.5, effort parameter and web_search tool filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,6 +168,7 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+*.iml
 
 # PyPI configuration file
 .pypirc

--- a/filter/anthropic_web_search_tool_filter.py
+++ b/filter/anthropic_web_search_tool_filter.py
@@ -1,0 +1,51 @@
+"""
+title: Anthropic Web Search Tool Filter
+description: Use Anthropic server-side web-search tool instead of Open WebUI built-in feature when enabled.
+author: Johan Grande
+inspired_by: https://github.com/owndev/Open-WebUI-Functions/blob/main/filters/google_search_tool.py
+version: 1.0.0
+license: MIT
+"""
+
+import logging
+import os
+
+from typing import Dict
+
+
+class Filter:
+    def __init__(self):
+        logging.basicConfig(level=os.getenv("LOG_LEVEL", "INFO"))
+
+    def inlet(self, body: Dict) -> Dict:
+        features = body.get("features", {}) or {}
+
+        # When the generic feature flag is set, attach Anthropic's web_search tool
+        if features.pop("web_search"):
+            logging.debug("Replacing web_search tool with Anthropic's own")
+            tools = body.setdefault("tools", [])
+            if not any(
+                isinstance(t, dict) and t.get("type") == "web_search" for t in tools
+            ):
+                tools.append(
+                    {
+                        "type": "web_search_20250305",
+                        "name": "web_search",
+                        # Optional: Limit the number of searches per request
+                        "max_uses": 5,
+                        # Optional: Only include results from these domains
+                        # "allowed_domains": ["example.com", "trusteddomain.org"],
+                        # Optional: Never include results from these domains
+                        # "blocked_domains": ["untrustedsource.com"],
+                        # Optional: Localize search results
+                        # "user_location": {
+                        #    "type": "approximate",
+                        #    "city": "San Francisco",
+                        #    "region": "California",
+                        #    "country": "US",
+                        #    "timezone": "America/Los_Angeles"
+                        # }
+                    }
+                )
+
+        return body

--- a/pipe/anthropic.py
+++ b/pipe/anthropic.py
@@ -62,7 +62,7 @@ import re
 import logging
 import asyncio
 import random
-from typing import List, Union, Dict, Optional, AsyncIterator, AsyncGenerator, Any
+from typing import List, Union, Dict, Optional, AsyncGenerator, Any
 import aiohttp
 from pydantic import BaseModel, Field
 from open_webui.utils.misc import pop_system_message
@@ -175,7 +175,7 @@ class Pipe:
         self._models_cache_time = None
     def _get_model_base(self, model_id: str) -> str:
         """Extracts the base name of a model for capability lookups."""
-        match = re.search(r"(claude-[\d\.\-a-z]+)-(\d{8}|latest)", model_id)
+        match = re.search(r"(claude-[\d.\-a-z]+)-(\d{8}|latest)", model_id)
         if match:
             base_id = match.group(1)
             if "sonnet-4" in base_id:

--- a/pipe/anthropic.py
+++ b/pipe/anthropic.py
@@ -709,9 +709,9 @@ class Pipe:
                     "budget_tokens": min(default_thinking_budget, out_cap - 1),
                 }
             if "tools" in body and self.valves.ENABLE_TOOL_CHOICE:
-                payload["tools"], payload["tool_choice"] = body["tools"], body.get(
-                    "tool_choice"
-                )
+                payload["tools"] = body["tools"]
+                if body.get("tool_choice"):
+                    payload["tool_choice"] = body.get("tool_choice")
             if self.valves.ENABLE_1M_CONTEXT and base_model in {"claude-sonnet-4", "claude-sonnet-4-5"}:
                 beta_headers_needed.add(self.BETA_HEADERS["CONTEXT_1M"])
             headers = {

--- a/pipe/anthropic.py
+++ b/pipe/anthropic.py
@@ -19,7 +19,7 @@ combines the best features from multiple community scripts into a single, robust
 future-proof solution.
 
 Changelog v8.6:
-- Add Opus 4.5, fix max_tokens/thinking.budget_tokens conflict
+- Add Haiku and Opus 4.5, fix max_tokens/thinking.budget_tokens conflict
 - Add effort parameter support
 
 Changelog v8.5:

--- a/pipe/anthropic.py
+++ b/pipe/anthropic.py
@@ -1,9 +1,9 @@
 """
 title: Final Unified Anthropic Pipe with Dynamic Discovery, Caching, and Streaming Tools
-authors: Balaxxe, nbellochi, Bermont, Mark Kazakov, Christian Taillon (Consolidated & Enhanced by AI)
+authors: Balaxxe, nbellochi, Bermont, Mark Kazakov, Christian Taillon, Johan Grande (Consolidated & Enhanced by AI)
 author_url: https://github.com/christian-taillon
 funding_url: https://github.com/open-webui
-version: 8.5
+version: 8.6
 license: MIT
 requirements: pydantic>=2.0.0, aiohttp>=3.8.0
 environment_variables:
@@ -13,9 +13,15 @@ environment_variables:
     - ANTHROPIC_REQUEST_TIMEOUT (optional, default: "300"): API request timeout in seconds
     - ANTHROPIC_MODEL_CACHE_TTL (optional, default: "3600"): Model list cache TTL in seconds
     - LOG_LEVEL (optional, default: "INFO"): Logging level
+
 This script is the definitive, all-in-one integration for Anthropic models in OpenWebUI. It
 combines the best features from multiple community scripts into a single, robust, and
 future-proof solution.
+
+Changelog v8.6:
+- Add Opus 4.5, fix max_tokens/thinking.budget_tokens conflict
+- Add effort parameter support
+
 Changelog v8.5:
 - Removed cost tracking functionality (ENABLE_COST_TRACKING valve, MODEL_PRICING, cost calculation methods)
 - Removed cost display from responses and event emissions
@@ -39,17 +45,19 @@ Changelog v8.2:
 - Added Claude 4.5 one-sampler logic with configurable temperature/top_p preference
 - Updated system message handling with new _prepare_system_blocks method
 - Fixed top_k logic to exclude when thinking is enabled (incompatible parameter)
+
 Changelog v8.1:
 - FIX: Corrected max_tokens for 128K models from 131,072 to the correct 128,000 limit.
 - Added Full Streaming Tool Use: Correctly handles and streams `tool_use` events.
 - Corrected Non-Streaming Tool Parsing: Fixed a bug in parsing tool calls from non-streamed responses.
+
 Key Features:
 - Dynamic Model Discovery: Fetches models directly from the Anthropic API (`/v1/models`)
   with a graceful fallback to a static list, ensuring it's always up-to-date.
 - Asynchronous Core: Uses `aiohttp` for high-performance, non-blocking API calls.
 - Complete Feature Set:
-    - Extended Thinking: With configurable budgets.
-    - 128K Output Tokens: For Claude 3.7 and 4 models.
+    - Extended Thinking: With configurable budgets and effort.
+    - 128K Output Tokens: For Claude 3.7.
     - Function Calling / Tool Use: Fully supported in both streaming and non-streaming modes.
 - Multi-Modal Support: Image and PDF document processing.
 - Intelligent Caching: Reduces costs and latency, with optional display of savings.
@@ -77,6 +85,7 @@ class Pipe:
         "PDF": "pdfs-2024-09-25",
         "OUTPUT_128K": "output-128k-2025-02-19",
         "CONTEXT_1M": "context-1m-2025-08-07",
+        "EFFORT": "effort-2025-11-24",
     }
     # Static capability metadata to enrich the dynamic model list
     MODEL_MAX_TOKENS = {
@@ -114,6 +123,11 @@ class Pipe:
         DISPLAY_THINKING: bool = Field(
             default=True,
             description="Display Claude's thinking process in chat (when thinking enabled)"
+        )
+
+        ENABLE_EFFORT: bool = Field(
+            default=True,
+            description="Apply Reasoning Effort parameter (beta, Opus 4.5 only)"
         )
 
         MAX_OUTPUT_TOKENS: bool = Field(
@@ -702,12 +716,21 @@ class Pipe:
                     beta_headers_needed.add(self.BETA_HEADERS["CACHING"])
             elif system_message:
                 payload["system"] = str(system_message)
+
             if is_thinking_variant and self.valves.ENABLE_THINKING:
                 default_thinking_budget = 16000 if re.search(r'[a-z]-3\b', base_model) else 32000
                 payload["thinking"] = {
                     "type": "enabled",
                     "budget_tokens": min(default_thinking_budget, out_cap - 1),
                 }
+            if self.valves.ENABLE_EFFORT and body.get("reasoning_effort") and model_id.startswith("claude-opus-4-5"):
+                effort = body.get("reasoning_effort").lower()
+                if effort in ["low", "medium", "high"]:
+                    payload["output_config"] = {"effort": effort}
+                    beta_headers_needed.add(self.BETA_HEADERS["EFFORT"])
+                else:
+                    logging.info(f"Ignoring invalid effort '{effort}'")
+
             if "tools" in body and self.valves.ENABLE_TOOL_CHOICE:
                 payload["tools"] = body["tools"]
                 if body.get("tool_choice"):
@@ -721,6 +744,8 @@ class Pipe:
             }
             if beta_headers_needed:
                 headers["anthropic-beta"] = ",".join(sorted(list(beta_headers_needed)))
+            logging.debug("payload: %s", payload)
+
             if payload["stream"]:
                 return self._stream_response(headers, payload, __event_emitter__, body)
             


### PR DESCRIPTION
In the pipeline:
- Add Haiku and Opus 4.5, fix max_tokens/thinking.budget_tokens conflict
- Add effort parameter support

I also added a filter to use Anthropic's server-side web search, inspired by https://github.com/owndev/Open-WebUI-Functions/blob/main/filters/google_search_tool.py. It can be taken out of the PR if you don't want it.